### PR TITLE
Add error callback to start method

### DIFF
--- a/mjpeg-camera.js
+++ b/mjpeg-camera.js
@@ -43,9 +43,10 @@ util.inherits(Camera, Stream);
 /**
  *  Open the connection to the camera and begin streaming
  *  and optionally performing motion analysis
+ *  @param {Function(Error, Buffer)} Error callback
  */
-Camera.prototype.start = function() {
-  var videostream = this._getVideoStream();
+Camera.prototype.start = function(errorCallback) {
+  var videostream = this._getVideoStream(errorCallback);
   videostream.on('data', this.onFrame.bind(this));
   if (this.motion) {
     videostream.pipe(new MotionStream()).pipe(this);


### PR DESCRIPTION
Adds a error callback to the `start` method, so consumers can be notified if there is an error first establishing a connection to the camera.